### PR TITLE
Translation spans (PR on your site-wide branch instead!)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,13 @@ description: "CollectionBuilder-GH is a template for creating small digital coll
 # creator of the digital collection, to appear in meta tags; we typically use our GitHub usernames but feel free to just use your name
 author: owikle
 
+# set languages used on site
+site_languages: 
+- lang_id: eng
+  lang_display: English
+- lang_id: spa
+  lang_display: Español
+
 ##########
 # COLLECTION SETTINGS
 #

--- a/_data/config-translation.csv
+++ b/_data/config-translation.csv
@@ -1,0 +1,3 @@
+span_id,description,eng,spa
+example1,Example heading,About Example,Acerca del ejemplo
+example2,example button text,Help,Ayuda 

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -2,6 +2,7 @@
 <script src="{{ '/assets/lib/jquery-3.6.0.min.js' | relative_url }}"></script>
 <script src="{{ '/assets/lib/bootstrap.bundle.min.js' | relative_url }}"></script>
 <!-- load other js -->
+{% include js/lang-js.html %}
 <script src="{{ '/assets/lib/lazysizes.min.js' | relative_url }}" async></script>
 {% if layout.gallery == true or page.gallery == true %}{% include js/gallery-js.html %}{% endif %}
 {% if page.custom-foot or layout.custom-foot %}
@@ -11,4 +12,3 @@
 {% for f in feet %}{% include {{ f }} %}
 {% endfor %}
 {%- endif -%}
-<script>{% include js/lang-js.js %}</script>

--- a/_includes/js/lang-js.html
+++ b/_includes/js/lang-js.html
@@ -1,3 +1,4 @@
+<script>
 // get site language, store in localStorage, or load from localStorage
 var site_language = ""; 
 if (localStorage.getItem("lang")) { 
@@ -32,3 +33,4 @@ $("input[name='lang_options']").change(function(){
 document.querySelector("#" + site_language).checked = true;
 
 //document.querySelectorAll(".eng").forEach( node => node.classList.add("display-none"));
+</script>

--- a/_includes/js/lang-js.html
+++ b/_includes/js/lang-js.html
@@ -33,4 +33,31 @@ $("input[name='lang_options']").change(function(){
 document.querySelector("#" + site_language).checked = true;
 
 //document.querySelectorAll(".eng").forEach( node => node.classList.add("display-none"));
+
+/* below is test translation span code --> not fully integrated with the switching above yet! */ 
+
+// set up translations dictionary
+var translations = { 
+    {% for t in site.data.config-translation %}
+    "{{ t.span_id }}": { 
+        {% for l in site.site_languages %}
+        "{{ l.lang_id }}": "{{ t[l.lang_id] }}"{% unless forloop.last %},{% endunless %}{% endfor %}
+    }{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+}
+// function to set all translated spans
+function fillTranslationSpans () {
+    // find all translate spans
+    document.querySelectorAll(".translate").forEach( node => {
+        // find text for site language
+        // there needs to be a bunch of ifs to ensure there is a fall back!
+        let span_text = translations[node.id][site_language];
+        // add to the span element
+        node.innerHTML = span_text;
+    });
+}
+// run function after load
+fillTranslationSpans();
+
+
 </script>

--- a/docs/translation-spans.md
+++ b/docs/translation-spans.md
@@ -1,0 +1,57 @@
+# Translation Spans
+
+CB uses a modular system to provide switching multiple languages for elements through out the site.
+
+The system has three parts:
+
+## site_languages 
+
+First, configure the languages that will be used on the site in "_config.yml".
+This will be used by the template to set up the buttons to switch between languages and set up the necessary data.
+This is done using a YAML dictionary starting with the key `site_languages`.
+Each language entry requires a `lang_id` (the three letter ISO code used as an identifier across the site) and a `lang_display` (the term you want to display on the language switching button).
+
+```
+# set languages used on site
+site_languages: 
+- lang_id: eng
+  lang_display: English
+- lang_id: spa
+  lang_display: Español
+```
+
+## config-translation
+
+Second, configure the bits of text that will be translated and switched between on your site using the "_data/config-translation.csv" file.
+The file has two required columns, plus an additional column for each language matching the `lang_id` configured above.
+Each row will describe one translation span that will be used on your site.
+Columns:
+
+- `span_id` is a unique string that will match the id attribute of a span element used somewhere in your site. It must be a valid html id attribute (no spaces, no slashes or quotes, no weird characters, etc)
+- `description` is a free text description of the element--this is not used in the template, but is just for information to help keep the translations organized and documented!
+- language columns - each additional language is a column named matching the `lang_id`. Each row will have the text for the corresponding language that will be added to the translation span.
+
+Example config:
+
+```
+span_id,description,eng,spa
+example1,Example heading,About Example,Acerca del ejemplo
+example2,example button text,Help,Ayuda 
+```
+
+## translation spans
+
+Third, are the span elements placed anywhere in the template where you need translated text. 
+Each translation span is an empty span element with an id attribute matching a `span_id` configured in "config-translation" and the class `translate`.
+For example:
+
+```
+<span id="example1" class="translate"></span>
+```
+
+Javascript on every page will scan the content for all spans with the `translate` class.
+For each of the spans, it will use the id to look up the configured translations, and fill in the span with the current language on the page.
+
+Translations spans can be used **anywhere** that is treated as html or markdown in the template. 
+For example, you can use them in "config-nav" display_name to provide translations for the navbar elements. 
+You can add them to the markdown of any page to set translations for the page headers and content. 

--- a/pages/about.md
+++ b/pages/about.md
@@ -8,6 +8,10 @@ credits: true
 # Look in _includes/feature for options to easily add features to the page
 ---
 
+# <span id="example1" class="translate"></span>
+
+<a href="" class="btn btn-success"><span id="example2" class="translate"></span>
+
 {% include feature/jumbotron.html objectid="https://cdil.lib.uidaho.edu/images/palouse_sm.jpg" %}
 
 {% include feature/nav-menu.html sections="About the Collection;About the About Page" %}


### PR DESCRIPTION
@owikle I quickly doc-ed and test implemented the span approach we discussed today. Actually seems pretty powerful??

I added it to the JS figuring out the current site_language, BUT did not actually combine the two. I didn't go far, so some possible kinks to work out, such as adding ifs to ensure there is a far back if nothing is configured, etc. It shouldn't be hard to integrate, just need to call it after figuring out the page language on load, then when ever the switch language buttons are pressed. 

I think this could replace part of what you did (with the hiding and showing classes). For example, you can use the spans directly in config-nav, which is probably easier than adding the extra columns. 
This doesn't currently relate to item page metadata display--but you might be able to use the approach there too (i.e. spans with id of the metadata fields to display, query the metadata to find the correct language; rather than setting up a bunch of spans with classes to hide/show). 